### PR TITLE
Update to javascript to correctly hide empty input groups. #242

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -132,12 +132,10 @@ function manuforma_adaptmorehtml()
 	$("img[src='resources/images/TEI-175.jpg']").attr("src","resources/images/hn/Text_Encoding_InitiativeTEI_Logo.svg");
 	 */ 
 	 
-	 /* Hides all elements in the toolbar */
-    $(".btn-toolbar .input-group").each(function(){
-        if($(this).find('.xforms-enabled').length !== 0) { console.log('enabled1'); }
-        else { $(this).hide(); }
-/*		if ($(this).children("span").length <= $(this).children(".xforms-disabled").length) $(this).hide();*/
-	});
+    /* Hide empty buttons.  */
+       $(".btn-toolbar .input-group").each(function() {
+            if ($(this).find(".xforms-group-content").children(".xforms-disabled").length > 0) $(this).hide();
+      })
 	 
 	$(".xforms-alert-icon").addClass("nobackground").html($('<i class="bi bi-x-circle"></i> Cancel'));
 	$("#edit .elementControls .justify-content-between").removeClass("justify-content-between");


### PR DESCRIPTION
@mMoliere this will hide the empty white boxes in the toolbar menus: 
<img width="1293" alt="Screenshot 2023-07-18 at 8 07 18 AM" src="https://github.com/majlis-erc/manuForma/assets/1168206/06ebaa04-6d0f-47a2-a03e-2f825c6c1c52">
