### PR TITLE
Update relations config to use new bibl lookup. #722

### DIFF
--- a/forms/formGenerator/config-relations.xml
+++ b/forms/formGenerator/config-relations.xml
@@ -44,7 +44,7 @@
             <lookup api="/exist/apps/majlis/api/search/title?format=xml&amp;q=" formURL="forms/mssTEI/lookup/title.xhtml" xpath="not(parent::*:bibl)" elementName="title" formName="title" lookupLabel="Look up title"/> -->
         <lookup api="/exist/apps/majlis/api/search/title?format=xml&amp;q=" formURL="forms/mssTEI/lookup/title.xhtml" elementName="title" formName="title" lookupLabel="Look up title"/>
         <popup formName="worksTEI" elementName="title" label="New work"/>
-        <lookup api="/exist/apps/majlis/api/search/citation?format=xml&amp;q=" formURL="forms/mssTEI/lookup/bibl.xhtml" elementName="bibl" formName="bibl" lookupLabel="Look up bibliographic record"/>
+        <lookup api="/exist/apps/majlis/api/search/simpleCite?format=xml&amp;q=" formURL="forms/mssTEI/lookup/bibl.xhtml" elementName="bibl" formName="bibl" lookupLabel="Look up bibliographic record"/>
     </lookups>
     <projectSpecificData>
         <xmlPath name="Project Picker" src="/forms/templates/editionStmtProjectOptions.xml" element="editionStmt"/>
@@ -94,7 +94,7 @@
                 formName="placeName" 
                 lookupLabel="Look up place record."/>
             <lookup 
-                api="/exist/apps/majlis/api/search/citation?format=xml&amp;q=" 
+                api="/exist/apps/majlis/api/search/simpleCite?format=xml&amp;q=" 
                 formURL="forms/relationTEI/lookup/bibl.xhtml" 
                 elementName="bibl" 
                 formName="bibl" 


### PR DESCRIPTION
Removes idno without disrupting existing lookups.

Needs to include update to https://github.com/majlis-erc/srophe before it works.
See: https://github.com/majlis-erc/srophe/pull/234