### PR TITLE
[bugfix] Add missing EXPath package dependencies

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://localhost/manuForma" abbrev="manuForma" version="0.7" spec="1.0">
     <title>manuForma</title>
+    <dependency processor="http://exist-db.org" semver-min="6.3.0"/>
+    <dependency package="http://exist-db.org/apps/xsltforms" version="1.0.0"/>
+    <dependency package="http://expath.org/ns/crypto" version="6.0.1"/>
+    <dependency package="http://exist-db.org/lib/githubxq" semver-min="1.0.0"/>
+    <dependency package="http://www.functx.com" semver-min="1.0.1"/>
 </package>


### PR DESCRIPTION
Fixes issues with trying to run this on eXist-db 6.3.0.