### PR TITLE
Fix issues that were preventing submission to GitHub

### DIFF
--- a/services/git-commit.xql
+++ b/services/git-commit.xql
@@ -84,7 +84,7 @@ declare function gitcommit:step1($data as item()*,$path as xs:string?, $commit-m
 
 declare function gitcommit:step2($data as item()*,$path as xs:string?, $commit-message as xs:string?, $branch-sha as xs:string?){
     (: 2. create a new branch :)
-    let $branch-name := concat(replace($path,'/|\.',''),'-',replace(util:random(),'\.',''))
+    let $branch-name := concat(replace($path,'/|\.',''),'-',replace(xs:string(util:random()),'\.',''))
     let $new-branch-name := 
         serialize(
             <object>

--- a/services/submit.xql
+++ b/services/submit.xql
@@ -355,10 +355,13 @@ return
                 return 
                  <response status="okay" code="200"><message>{$save} Record {$id} saved, thank you for your contribution. </message></response>  
             } catch * {
-                (response:set-status-code( 500 ),
-                <response status="fail">
-                    <message>Failed to update resource {$id}: {concat($err:code, ": ", $err:description)}</message>
-                </response>)
+                (
+                    util:log("ERROR", concat("Failed to update resource: ", $id, ". [", $err:line-number, ":", $err:column-number, "]", $err:module, ": ", $err:code, " ", $err:description)),
+                    response:set-status-code(500),
+                    <response status="fail">
+                      <message>Failed to update resource: {$id}. {concat($err:code, ": ", $err:description)}</message>
+                    </response>
+                )
             }
          else if(request:get-parameter('type', '') = 'github') then 
             try {
@@ -372,11 +375,13 @@ return
                  </response>
                  )
             } catch * {
-                (response:set-status-code( 500 ),
-                <response status="fail">
-                    <message>Failed to submit, please download your changes and send via email. {concat($err:code, ": ", $err:description)}</message>
-                    
-                </response>)
+                (
+                  util:log("ERROR", concat("Failed to submit, please download your changes and send via email. [", $err:line-number, ":", $err:column-number, "]", $err:module, ": ", $err:code, " ", $err:description)),
+                  response:set-status-code(500),
+                  <response status="fail">
+                      <message>Failed to submit, please download your changes and send via email. {concat($err:code, ": ", $err:description)}</message>
+                  </response>
+                )
             }   
         else if(request:get-parameter('type', '') = 'download') then
                 (response:set-header("Content-Type", "application/xml; charset=utf-8"),

--- a/services/submit.xql
+++ b/services/submit.xql
@@ -89,7 +89,8 @@ declare function local:transform($nodes as node()*) as item()* {
                         for $n in $node/node()
                         return local:transform($n)
                     }
-            else element {fn:QName("http://www.tei-c.org/ns/1.0",local-name($node))} {($node/@*, local:markdown2TEI($node/node()))}
+            else
+              local:passthru($node)
         case element(tei:editor) return
             if($node/parent::tei:titleStmt) then 
                 if($user != 'guest') then


### PR DESCRIPTION
1. Fixes a data type conversion issues (xs:double -> xs:string); used for generating a random Git branch name
2. Make sure that other <ab> elements are copied from the input to the output.
3. Make sure to log details of errors when they occur to exist.log.