### PR TITLE
[bugfix] Make sure that elements copied into the record do not carry xmlns=""

### DIFF
--- a/src/main/formGenerator/config-documentation.xml
+++ b/src/main/formGenerator/config-documentation.xml
@@ -76,7 +76,7 @@
             @collection - collections to be searched, should match collections in your data directory. To specify multiple collections separate with a comma: manuscripts,works,persons
             @wrapElement - element that will contain the search results, if different from the name of the searched element.
                 For example the following searches all persNames, but returns results wrapped in author element for insertion into TEI record: 
-                /exist/apps/majlis/api/search/persName?format=xml&amp;wrapElement=author&amp;q=
+                /exist/apps/majlis/api/search/persName?format=xml&wrapElement=tei:author&q=
             @q - query to search 
         elementName - the element that will trigger the lookup
         formName - the name of the lookup form (usually uses same name as element, for simplicity)
@@ -153,4 +153,4 @@
             </elementGroups>
         </subform>     
     </subforms>
-</config>   
+</config>

--- a/src/main/formGenerator/config-mss.xml
+++ b/src/main/formGenerator/config-mss.xml
@@ -72,7 +72,7 @@
             lookupLabel="Look up places."/>
         <popup formName="placeTEI" elementName="placeName" label="New place"/>
         <lookup
-            api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=author&amp;q=" 
+            api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=tei%3Aauthor&amp;q="
             formURL="forms/msSimple/lookup/author.xhtml" 
             elementName="author" 
             formName="author" 
@@ -101,7 +101,7 @@
             @collection - collections to be searched, should match collections in your data directory
             @wrapElement - element that will contain the search results, if different from the name of the request
                 example the following searches all persNames, but returns results wrapped in author element for insertion into TEI record: 
-                /exist/apps/majlis/api/search/persName?format=xml&amp;wrapElement=author&amp;q=
+                /exist/apps/majlis/api/search/persName?format=xml&wrapElement=tei:author&q=
             @q - query to search 
         elementName - the element that will trigger the lookup
         formName - the name of the lookup form (usually uses same name as element, for simplicity)
@@ -269,7 +269,7 @@
             <localSchema src="schemas/mss-codicological-definition.xml"/>
             <globalSchema src="schemas/mss-codicological-definition.xml"/>
             <xmlTemplate src="templates/full-mss-template.xml"/>
-            <lookup api="/exist/apps/majlis/api/search/biblWorksCitation?format=xml&amp;collection=manuscripts&amp;wrapElement=idno&amp;q="
+            <lookup api="/exist/apps/majlis/api/search/biblWorksCitation?format=xml&amp;collection=manuscripts&amp;wrapElement=tei%3Aidno&amp;q="
                 elementName="bibl"
                 formName="bibl"
                 lookupLabel="Look up manuscript record"/>
@@ -297,7 +297,7 @@
             <globalSchema src="schemas/mss-content-description.xml"/>
             <xmlTemplate src="templates/full-mss-template.xml"/>
             <lookup
-                api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=author&amp;q=" 
+                api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=tei%3Aauthor&amp;q="
                 formURL="forms/msSimple/lookup/author.xhtml" 
                 elementName="author" 
                 formName="author" 
@@ -323,7 +323,7 @@
             <localSchema src="schemas/mss-writing-material.xml"/>
             <globalSchema src="schemas/mss-compiled.odd"/>
             <xmlTemplate src="templates/full-mss-template.xml"/>
-            <lookup api="/exist/apps/majlis/api/search/placeName?format=xml&amp;wrapElement=origPlace&amp;q=" formURL="forms/msSimple/lookup/placeName.xhtml" elementName="origPlace" formName="placeName" lookupLabel="Look up places"/>
+            <lookup api="/exist/apps/majlis/api/search/placeName?format=xml&amp;wrapElement=tei%3AorigPlace&amp;q=" formURL="forms/msSimple/lookup/placeName.xhtml" elementName="origPlace" formName="placeName" lookupLabel="Look up places"/>
             <formDesc>Describe the writing material, measurements and related additional properties of the manuscript.</formDesc>
             <elementGroups>
                 <group groupLabel="Writing material of the manuscript." groupLabelConditionalElement="./*:material"
@@ -525,7 +525,7 @@
                 formName="bibl" 
                 lookupLabel="Look up bibliographic record."/>
             <lookup
-                api="/exist/apps/majlis/api/search/titleBibl?format=xml&amp;collection=manuscripts&amp;wrapElement=idno&amp;q=" 
+                api="/exist/apps/majlis/api/search/titleBibl?format=xml&amp;collection=manuscripts&amp;wrapElement=tei%3Aidno&amp;q="
                 formURL="forms/msSimple/lookup/titleBibl.xhtml" 
                 elementName="idno" 
                 formName="idno" 
@@ -603,7 +603,7 @@
             <globalSchema src="schemas/mss-compiled.odd"/>
             <xmlTemplate src="templates/full-mss-template.xml"/>
             <formDesc>Describe the binding of the manuscript.</formDesc>
-            <lookup api="/exist/apps/majlis/api/search/placeName?format=xml&amp;collection=places&amp;wrapElement=origPlace&amp;q=" 
+            <lookup api="/exist/apps/majlis/api/search/placeName?format=xml&amp;collection=places&amp;wrapElement=tei%3AorigPlace&amp;q="
                 formURL="forms/msSimple/lookup/placeName.xhtml" 
                 elementName="origPlace" 
                 formName="placeName" 

--- a/src/main/formGenerator/config-persons.xml
+++ b/src/main/formGenerator/config-persons.xml
@@ -42,7 +42,7 @@
             @collection - collections to be searched, should match collections in your data directory
             @wrapElement - element that will contain the search results, if different from the name of the request
                 example the following searches all persNames, but returns results wrapped in author element for insertion into TEI record: 
-                /exist/apps/majlis/api/search/persName?format=xml&amp;wrapElement=author&amp;q=
+                /exist/apps/majlis/api/search/persName?format=xml&wrapElement=author&q=
             @q - query to search 
         elementName - the element that will trigger the lookup
         formName - the name of the lookup form (usually uses same name as element, for simplicity)

--- a/src/main/formGenerator/config-works.xml
+++ b/src/main/formGenerator/config-works.xml
@@ -43,7 +43,7 @@
     <lookups>
         <lookup api="/exist/apps/majlis/api/search/persName?format=xml&amp;q=" formURL="forms/mssTEI/lookup/persName.xhtml" elementName="persName" formName="persName" lookupLabel="Look up persons"/>
         <popup formName="personTEI" elementName="persName" label="New person"/>
-        <lookup api="/exist/apps/majlis/api/search/biblWorksAuthor?format=xml&amp;collection=persons&amp;wrapElement=author&amp;q=" formURL="forms/worksTEI/lookup/persName.xhtml" elementName="author" formName="persName" lookupLabel="Look up authors"/>
+        <lookup api="/exist/apps/majlis/api/search/biblWorksAuthor?format=xml&amp;collection=persons&amp;wrapElement=tei%3Aauthor&amp;q=" formURL="forms/worksTEI/lookup/persName.xhtml" elementName="author" formName="persName" lookupLabel="Look up authors"/>
         <popup formName="personTEI" elementName="authors" label="New author"/>
         <lookup api="/exist/apps/majlis/api/search/placeName?format=xml&amp;q=" formURL="forms/mssTEI/lookup/placeName.xhtml" elementName="placeName" formName="placeName" lookupLabel="Look up places"/>
         <popup formName="placeTEI" elementName="placeName" label="New place"/>
@@ -91,13 +91,13 @@
             <globalSchema src="schemas/work-schema.xml"/>
             <xmlTemplate src="templates/work-fulltemplate.xml"/>
             <lookup
-                api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=author&amp;q="
+                api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=tei%3Aauthor&amp;q="
                 formURL="forms/msSimple/lookup/author.xhtml"
                 elementName="author"
                 formName="author"
                 lookupLabel="Look up author record."/>
             <lookup
-                api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=persName&amp;q="
+                api="/exist/apps/majlis/api/search/persName?format=xml&amp;collection=persons&amp;wrapElement=tei%3ApersName&amp;q="
                 formURL="forms/msSimple/lookup/author.xhtml"
                 elementName="persName"
                 formName="persName"


### PR DESCRIPTION
Previously elements were returned from the Majlis (Srophe) API in the default XML namespace (i.e. `xmlns=""`) and were then copied by the XForm verbatim into a TEI namespaced document. This menat that elements would be added to the TEI document that were not in the TEI namespace but were in the default XML namespace. This PR updates the lookups so that the returned elements are in the TEI namespace.